### PR TITLE
WIP: Add Troubleshooting Section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Building
 ---
 There is a ```build_notes``` subdirectory explaining the methodology of how to build this plugin.  Essentially, how we get from 'sample code distributed by openvpn' to 'our plugin'.
 
-
+Troubleshooting
+---
+The plugin was tested against OpenVPN 2.4.6 initially. The plugin completely fails to run on any older versions.
 
 License
 ---
@@ -28,4 +30,4 @@ The plugin is greatly derived from their sample code.
 
 To avoid any license/redistribution concerns, I'd love to use a submodule here and say "get it from their repo".  But their git has ```openvpn-plugin.h``` as a pre-autoconf ```.in``` file.  And I COULD have you do it with a lot of autoconf.  But then you'd be building against something that wasn't their shipped code.
 
-As such, I've shipped this repo without the .h file.  The plugin was tested against 2.4.6 initially.
+As such, I've shipped this repo without the .h file.


### PR DESCRIPTION
Ubuntu 18.04 LTS ships OpenVPN 2.4.4; the plugin compiles without any issues, but fails to run.

```sh
tail -f /var/log/openvpn/openvpn.log
Tue Jun 18 18:53:55 2019 us=339090 PLUGIN_INIT: POST /usr/lib/x86_64-linux-gnu/openvpn/plugins/openvpn_defer_auth.so '[/usr/lib/x86_64-linux-gnu/openvpn/plugins/openvpn_defer_auth.so] [/etc/openvpn/test.sh]' intercepted=PLUGIN_UP|PLUGIN_DOWN|PLUGIN_ROUTE_UP|PLUGIN_IPCHANGE|PLUGIN_TLS_VERIFY|PLUGIN_AUTH_USER_PASS_VERIFY|PLUGIN_CLIENT_CONNECT|PLUGIN_CLIENT_DISCONNECT|PLUGIN_LEARN_ADDRESS|PLUGIN_CLIENT_CONNECT|PLUGIN_TLS_FINAL|PLUGIN_ENABLE_PF|PLUGIN_ROUTE_PREDOWN
Tue Jun 18 18:53:55 2019 us=339260 PLUGIN_INIT: plugin initialization function failed: /usr/lib/x86_64-linux-gnu/openvpn/plugins/openvpn_defer_auth.so
Tue Jun 18 18:53:55 2019 us=339405 Exiting due to fatal error
```